### PR TITLE
[ fix ] Re-export Control.Barbie in Derive.Barbie

### DIFF
--- a/src/Derive/Barbie.idr
+++ b/src/Derive/Barbie.idr
@@ -6,6 +6,7 @@ import public Derive.DistributiveB
 import public Derive.FunctorB
 import public Derive.RecordB
 import public Derive.TraversableB
+import public Control.Barbie
 import Language.Reflection.Util
 
 ||| Generate declarations for all barbie interfaces


### PR DESCRIPTION
`Control.Barbie` should probably be re-exported in `Derive.Barbie`, since the latter is pretty much useless without the former anyway.